### PR TITLE
fix: chatgpt overlay getting clipped by textbox boundary

### DIFF
--- a/src/chatgpt/content.ts
+++ b/src/chatgpt/content.ts
@@ -1501,9 +1501,9 @@ function showButtonPopup(button: HTMLElement, message: string): void {
   if (!host) {
     return;
   }
-  let root = host.shadowRoot || host;
-  // Remove any existing popups
-  const existingPopup = root.querySelector('.mem0-button-popup');
+  
+  // Remove any existing popups from document body
+  const existingPopup = document.querySelector('.mem0-button-popup');
   if (existingPopup) {
     existingPopup.remove();
   }
@@ -1515,13 +1515,16 @@ function showButtonPopup(button: HTMLElement, message: string): void {
     hoverPopover.style.display = 'none';
   }
 
+  // Get button position relative to viewport
+  const buttonRect = host.getBoundingClientRect();
+  
   const popup = document.createElement('div');
   popup.className = 'mem0-button-popup';
 
   popup.style.cssText = `
-    position: absolute;
-    top: -40px;
-    left: 50%;
+    position: fixed;
+    top: ${buttonRect.top - 50}px;
+    left: ${buttonRect.left + buttonRect.width / 2}px;
     transform: translateX(-50%);
     background-color: #1C1C1E;
     border: 1px solid #27272A;
@@ -1530,8 +1533,9 @@ function showButtonPopup(button: HTMLElement, message: string): void {
     border-radius: 6px;
     font-size: 12px;
     white-space: nowrap;
-    z-index: 10001;
+    z-index: 2147483647;
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+    pointer-events: none;
   `;
 
   popup.textContent = message;
@@ -1551,7 +1555,7 @@ function showButtonPopup(button: HTMLElement, message: string): void {
   `;
 
   popup.appendChild(arrow);
-  root.appendChild(popup);
+  document.body.appendChild(popup);
 
   setTimeout(function () {
     if (popup.isConnected) {
@@ -1926,15 +1930,15 @@ function hookBackgroundSearchTyping() {
   }
 
   if (inputElement.dataset.mem0BackgroundHooked) {
-    return; 
+    return;
   }
 
-  inputElement.dataset.mem0BackgroundHooked = 'true'; 
+  inputElement.dataset.mem0BackgroundHooked = 'true';
 
   if (!chatgptBackgroundSearchHandler) {
     chatgptBackgroundSearchHandler = function () {
       const text = getInputValue() || '';
-      console.log("Background search for:", text); 
+      console.log('Background search for:', text);
       chatgptSearch.setText(text);
     };
   }


### PR DESCRIPTION
The mem0 overlay in ChatGPT gets clipped by the bounding chatbox when clicked during an empty message.

Bug:
<img width="1440" height="900" alt="Screenshot 2025-11-30 at 12 48 09 PM" src="https://github.com/user-attachments/assets/0c12424f-f209-4219-a7c9-eb5f1e68f2f1" />

Fix:
<img width="1440" height="900" alt="Screenshot 2025-11-30 at 1 19 08 PM" src="https://github.com/user-attachments/assets/7d8fd24a-d6f0-4714-93a2-60bc1d32edb1" />